### PR TITLE
Automatically focus search bar in the app launcher

### DIFF
--- a/ags/modules/sideleft/applauncher.ts
+++ b/ags/modules/sideleft/applauncher.ts
@@ -153,7 +153,7 @@ export const Applauncher = () => {
                 if (visible) {
                     repopulate();
                     entry.text = "";
-                    entry.grab_focus(); // Automatically focus the search bar
+                    entry.grab_focus();
                 }
             })
     });

--- a/ags/modules/sideleft/applauncher.ts
+++ b/ags/modules/sideleft/applauncher.ts
@@ -107,13 +107,6 @@ export const Applauncher = () => {
         vertical: true
     });
 
-    function repopulate() {
-        applications = query("").map(AppItem);
-        applications = sortApplicationsByLaunchCount(applications);
-        list.children = applications;
-    }
-    repopulate();
-
     const entry = Widget.Entry({
         hexpand: true,
         class_name: "applauncher_entry",
@@ -132,6 +125,13 @@ export const Applauncher = () => {
                 item.visible = item.attribute.app.match(text ?? "");
             })
     });
+
+    function repopulate() {
+        applications = query("").map(AppItem);
+        applications = sortApplicationsByLaunchCount(applications);
+        list.children = applications;
+    }
+    repopulate();
 
     return Widget.Box({
         vertical: true,
@@ -153,6 +153,7 @@ export const Applauncher = () => {
                 if (visible) {
                     repopulate();
                     entry.text = "";
+                    entry.grab_focus(); // Automatically focus the search bar
                 }
             })
     });


### PR DESCRIPTION
I'm just to typing out applications instead of manually clicking on them. Since the search bar wasn't automatically focused before I made this change, I had to manually click on it each time.

The search bar is not automatically focused when navigating to the app launcher tab from the sidebar, only when using the keyboard shortcut.