### PR TITLE
fix hyprlock and add fingerprint support

### DIFF
--- a/material-colors/templates/hyprlock.conf
+++ b/material-colors/templates/hyprlock.conf
@@ -19,13 +19,21 @@
         vibrancy = 0.1696
         vibrancy_darkness = 0.0
     }
+    # (auth config)
+    auth {
+        fingerprint {
+            enabled = true
+            ready_message =
+            present_message =
+        }
+    }
 #
 
 # Password input
     input-field {
         monitor =
         size = 225, 50
-        outline_thickness = 3
+        outline_thickness = -1
         dots_size = 0.33
         dots_spacing = 0.45
         dots_center = true
@@ -33,10 +41,10 @@
         outer_color = rgba(0,0,0,0)
         inner_color = rgba(0,0,0,0)
         font_color = rgba(<primaryFixed.rgb>, 1.0)
-        fade_on_empty = false
+        fade_on_empty = true
         fade_timeout = 1000
         font_family = Product Sans
-        placeholder_text = 
+        placeholder_text =
         hide_input = false
         rounding = 4
         check_color = rgba(0,0,0,0)


### PR DESCRIPTION
There was an unintended white background to the input field on the latest version of Hyprlock.\
Additionally, this PR adds support for users that have a fingerprint sensor set up. In theory, users shouldn't notice any difference even if they don't have a fingerprint sensor, as they can type out their password like normal.