### PR TITLE
fix issues with window/layer rules (-> v2)

### DIFF
--- a/hypryou-assets/hyprland/windowrule.conf
+++ b/hypryou-assets/hyprland/windowrule.conf
@@ -1,42 +1,42 @@
 # ######## Window rules ########
-windowrule = tile, class:^(Microsoft-edge)$
-windowrule = tile, class:^(Brave-browser)$
-windowrule = tile, class:^(Chromium)$
-windowrule = float, class:^(blueman-manager)$
-windowrule = float, class:^(blueberry.py)$
-windowrule = float, class:^(nm-connection-editor)$
-windowrule = float, class:^(qalculate-gtk)$
-windowrule = float, class:^(steam)$
-windowrule = float, class:^(com.koeqaife.hypryou)$
-windowrule = stayfocused, title:^()$, class:^(steam)$
-windowrule = minsize 1 1, title:^()$, class:^(steam)$
-windowrule = float, title:^(Volume Control)(.*)$
+windowrulev2 = tile, class:^(Microsoft-edge)$
+windowrulev2 = tile, class:^(Brave-browser)$
+windowrulev2 = tile, class:^(Chromium)$
+windowrulev2 = float, class:^(blueman-manager)$
+windowrulev2 = float, class:^(blueberry.py)$
+windowrulev2 = float, class:^(nm-connection-editor)$
+windowrulev2 = float, class:^(qalculate-gtk)$
+windowrulev2 = float, class:^(steam)$
+windowrulev2 = float, class:^(com.koeqaife.hypryou)$
+windowrulev2 = stayfocused, title:^()$, class:^(steam)$
+windowrulev2 = minsize 1 1, title:^()$, class:^(steam)$
+windowrulev2 = float, title:^(Volume Control)(.*)$
 
 # Xwaylandvideobridge (if installed)
-windowrule = opacity 0.0 override, class:^(xwaylandvideobridge)$
-windowrule = noanim, class:^(xwaylandvideobridge)$
-windowrule = noinitialfocus, class:^(xwaylandvideobridge)$
-windowrule = maxsize 1 1, class:^(xwaylandvideobridge)$
-windowrule = noblur, class:^(xwaylandvideobridge)$
+windowrulev2 = opacity 0.0 override, class:^(xwaylandvideobridge)$
+windowrulev2 = noanim, class:^(xwaylandvideobridge)$
+windowrulev2 = noinitialfocus, class:^(xwaylandvideobridge)$
+windowrulev2 = maxsize 1 1, class:^(xwaylandvideobridge)$
+windowrulev2 = noblur, class:^(xwaylandvideobridge)$
 
 # Dialogs
-windowrule = float, title:^(Open File)(.*)$
-windowrule = float, title:^(Select a File)(.*)$
-windowrule = float, title:^(Choose wallpaper)(.*)$
-windowrule = float, title:^(Open Folder)(.*)$
-windowrule = float, title:^(Save As)(.*)$
-windowrule = float, title:^(Library)(.*)$
-windowrule = float, title:^(File Upload)(.*)$
+windowrulev2 = float, title:^(Open File)(.*)$
+windowrulev2 = float, title:^(Select a File)(.*)$
+windowrulev2 = float, title:^(Choose wallpaper)(.*)$
+windowrulev2 = float, title:^(Open Folder)(.*)$
+windowrulev2 = float, title:^(Save As)(.*)$
+windowrulev2 = float, title:^(Library)(.*)$
+windowrulev2 = float, title:^(File Upload)(.*)$
 
 # Tearing
-windowrule = immediate, class:.*\.exe
-windowrule = immediate, class:(steam_app)455
+windowrulev2 = immediate, class:.*\.exe
+windowrulev2 = immediate, class:(steam_app)455
 
 # ######## Layer rules ########
-# layerrule = xray 1, .*
-# layerrule = noanim, .*
-layerrule = noanim, selection
-layerrule = noanim, popup.*
-layerrule = noanim, hyprpicker
-layerrule = noanim, noanim
-layerrule = noanim, wallpapers
+# layerrulev2 = xray 1, .*
+# layerrulev2 = noanim, .*
+layerrulev2 = noanim, selection
+layerrulev2 = noanim, popup.*
+layerrulev2 = noanim, hyprpicker
+layerrulev2 = noanim, noanim
+layerrulev2 = noanim, wallpapers

--- a/hypryou/src/services/hyprland_config.py
+++ b/hypryou/src/services/hyprland_config.py
@@ -200,8 +200,8 @@ def generate_blur() -> str:
     xray = settings.get("blur.xray")
 
     output = (
-        "layerrule = blur, hypryou-.*",
-        "layerrule = ignorealpha 0.85, hypryou-.*",
+        "layerrulev2 = blur, hypryou-.*",
+        "layerrulev2 = ignorealpha 0.85, hypryou-.*",
         BLUR.format("true" if xray else "false")
     )
     return "\n".join(output)
@@ -209,7 +209,7 @@ def generate_blur() -> str:
 
 def generate_noanim() -> str:
     return "\n".join(
-        f"layerrule = noanim, {layer}"
+        f"layerrulev2 = noanim, {layer}"
         for layer in noanim_layers
     ) + "\n"
 


### PR DESCRIPTION
Starting from Hyprland v0.5.3, for some reason (I didn't really research) the current `layerrule` and `windowrule`s won't work, unless you change them to `layerrulev2` and `windowrulev2` for each one of them , which is what this pull request does.