### PR TITLE
Fix split-mode keybinding for Hyprland v0.54+

### DIFF
--- a/hypryou/src/services/hyprland_keybinds/windows.py
+++ b/hypryou/src/services/hyprland_keybinds/windows.py
@@ -57,7 +57,7 @@ key_binds = (
     ),
     KeyBind(
         (main_mod, "J"),
-        "togglesplit",
+        ("layoutmsg", "togglesplit"),
         "Toggle split mode",
         Category.WINDOWS
     ),


### PR DESCRIPTION

### Changes

* Replace deprecated `togglesplit` dispatcher usage
* Use `layoutmsg, togglesplit` for the split toggle binding

### Why

Hyprland removed direct `togglesplit` dispatcher support in newer versions, so the previous binding no longer works.
reff: 
https://wiki.hypr.land/Configuring/Dwindle-Layout/

### Result

The split-mode keybinding works again on current Hyprland versions.

