### PR TITLE
Unlocking the lock screen no longer crashes HyprYou Desktop.

### DIFF
--- a/hypryou/src/modules/lockscreen.py
+++ b/hypryou/src/modules/lockscreen.py
@@ -304,9 +304,9 @@ class ScreenLockWindow(gtk.ApplicationWindow):
         self.add_css_class("faded-out")
 
         def _on_done() -> bool:
+            self.destroy()
             if on_done:
                 on_done()
-            self.destroy()
             return False
 
         glib.timeout_add(320, _on_done)


### PR DESCRIPTION
As the title says, with this fix, hypryou no longer crashes when you unlock your lockscreen :D