### PR TITLE
Add SUPER+SHIFT+L keybind to launch system info terminals

### DIFF
--- a/hypryou/src/services/hyprland_keybinds/apps.py
+++ b/hypryou/src/services/hyprland_keybinds/apps.py
@@ -30,5 +30,11 @@ key_binds = (
         ("exec", "hypryouctl apps files"),
         "File Manager",
         Category.APPS
+    ),
+    KeyBind(
+        (main_mod, "SHIFT", "L"),
+        ("exec", "sh -c \"TERM=$(hypryouctl apps terminal); $TERM -e sh -c 'fastfetch; read' & $TERM -e sh -c 'btop; read' & $TERM -e sh -c 'cava; read' & $TERM -e sh -c 'cmatrix; read'\""),
+        "Launch system dashboard",
+        Category.APPS
     )
 )

--- a/hypryou/src/services/hyprland_keybinds/apps.py
+++ b/hypryou/src/services/hyprland_keybinds/apps.py
@@ -33,7 +33,7 @@ key_binds = (
     ),
     KeyBind(
         (main_mod, "SHIFT", "L"),
-        ("exec", "sh -c \"TERM=$(hypryouctl apps terminal); $TERM -e sh -c 'fastfetch; read' & $TERM -e sh -c 'btop; read' & $TERM -e sh -c 'cava; read' & $TERM -e sh -c 'cmatrix; read'\""),
+        ("exec", "sh -c \"TERM=$(hypryouctl apps terminal); $TERM -e sh -c 'btop; read' & sleep 0.1; $TERM -e sh -c 'fastfetch; read' & sleep 0.1; $TERM -e sh -c 'htop; read' & sleep 0.1; $TERM -e sh -c 'cava; read' & sleep 0.1; $TERM -e sh -c 'cmatrix; read'\""),
         "Launch system dashboard",
         Category.APPS
     )


### PR DESCRIPTION
Added a new bind (SUPER+SHIFT+L) that opens a few terminal windows
running fastfetch, btop, cava, and cmatrix. (larp keybind)