### PR TITLE
fix: audio device lists empty after restart, volume reset to ~1%

### DIFF
--- a/hypryou/src/modules/settings/bluetooth.py
+++ b/hypryou/src/modules/settings/bluetooth.py
@@ -3,6 +3,7 @@ from repository import gtk, bluetooth, gdk, gio, glib
 from src.modules.settings.base import RowTemplate
 from src.services.apps import launch_detached
 import typing as t
+from utils.logger import logger
 from utils.styles import toggle_css_class
 import src.widget as widget
 from collections import defaultdict
@@ -92,7 +93,12 @@ class BluetoothToggle(RowTemplate):
         if self.discovering_handler and self.adapter:
             self.adapter.disconnect(self.discovering_handler)
         if self.adapter and self.adapter.get_discovering():
-            self.adapter.stop_discovery()
+            try:
+                self.adapter.stop_discovery()
+            except glib.GError:
+                logger.warning(
+                    "Failed to stop bluetooth discovery", exc_info=True
+                )
 
 
 icons_map = defaultdict(

--- a/hypryou/src/services/audio.py
+++ b/hypryou/src/services/audio.py
@@ -89,7 +89,7 @@ class AudioService(Service):
 
     # Speaker: Volume
     def on_volume_ref_changed(self, new_value: float) -> None:
-        volume = self.default_speaker.get_volume() * 100.0
+        volume = self.default_speaker.get_volume() * 100.0 # keep the current vol after restart 
         if volume == new_value:
             return
         self.default_speaker.set_volume(new_value / 100.0)
@@ -139,7 +139,7 @@ class AudioService(Service):
     def app_init(self) -> None:
         if not self.success:
             return
-        volume.value = self.default_speaker.get_volume()
+        volume.value = self.default_speaker.get_volume() * 100.0
         volume.watch(self.on_volume_ref_changed)
         volume_muted.watch(self.on_muted_ref_changed)
         self.default_speaker.connect("notify::volume", self.on_volume_changed)
@@ -175,3 +175,13 @@ class AudioService(Service):
                 f"{node}-removed",
                 lambda _, n, c=container: c.value.discard(n)
             )
+
+        
+        for speaker in self.audio.get_speakers() or ():
+            speakers.value.add(speaker)
+        for microphone in self.audio.get_microphones() or ():
+            microphones.value.add(microphone)
+        for stream in self.audio.get_streams() or ():
+            streams.value.add(stream)
+        for recorder in self.audio.get_recorders() or ():
+            recorders.value.add(recorder)


### PR DESCRIPTION
Two small, unrelated fixes that both showed up around UI restarts (reload
or a watchdog restart), so I bundled them together.

**Audio device lists coming up empty after restart**
The `*-added` signals from WirePlumber only fire for nodes discovered
*after* you subscribe. On a cold boot that's fine, the UI subscribes
before WirePlumber finishes its own discovery, so it still catches
everything as it comes in. But on a restart, discovery has already
happened — no new add signal ever fires, so the speaker/microphone/stream
lists just stay empty even though the devices are still there. Looked
exactly like audio "resetting" itself, took a while to realize it wasn't
losing anything, it just never asked.

**Volume dropping to ~1% on reload**
Related, while fixing the above I noticed the initial volume was being
set as a raw 0–1 value while the rest of the code works on a 0–100 scale.
So the first time any widget wrote the volume back, it'd collapse down to
around 1%. Small mismatch, easy miss.

**Bluetooth crashing when you close settings**
Closing the settings window tears down the Bluetooth page, which calls
`adapter.stop_discovery()`. If discovery wasn't actually running at that
point, BlueZ throws back `GDBus.Error:org.bluez.Error.Failed: No
discovery started`, and that was going uncaught and taking the whole
shell down with it


- seed the speaker/microphone/stream/recorder lists at init by calling
  `get_speakers()` / `get_microphones()` / `get_streams()` /
  `get_recorders()`, instead of relying only on add signals
- fixed the initial volume to use the 0–100 scale like everywhere else
- wrapped `stop_discovery()` in a try/except so a failed discovery stop
  doesn't crash the UI on teardown