### PR TITLE
Fix the two config errors from the Lua migration

### DIFF
--- a/hypryou/src/services/hyprland_config.py
+++ b/hypryou/src/services/hyprland_config.py
@@ -213,6 +213,8 @@ def generate_monitors() -> str:
                     value = text_to_bool(value)
                 if key == "bitdepth":
                     value = int(value)
+                if key == "transform":
+                    value = int(value)
                 output += f"    {key} = {serialize_value(value)},\n"
             output += "})\n"
     return output

--- a/hypryou/src/services/hyprland_config.py
+++ b/hypryou/src/services/hyprland_config.py
@@ -402,6 +402,10 @@ def generate_binds() -> str:
             if override.action:
                 action_str = override.action
 
+        if any(str(k).upper() in ("NULL", "NONE") for k in
+               (key if isinstance(key, tuple) else (key,))):
+            continue
+
         if isinstance(key, tuple):
             key_str = serialize_value(" + ".join(key))
         else:


### PR DESCRIPTION
Fixes the two errors Hyprland shows on startup after the Lua migration: transform is written as a string instead of an int, and a cleared shortcut is written out as a key called NULL.