### PR TITLE
Fix startup crash with pywayland 0.4.19

### DIFF
--- a/hypryou/src/services/idle.py
+++ b/hypryou/src/services/idle.py
@@ -7,10 +7,16 @@ from repository import gio, glib
 from utils.logger import logger
 import typing as t
 from pywayland.client.display import Display
-from pywayland.protocol.wayland import WlSeat
-from pywayland.protocol.ext_idle_notify_v1 import (
-    ExtIdleNotifierV1, ExtIdleNotifierV1Proxy as Notifier
-)
+try:
+    from pywayland.protocol.wayland import WlSeat
+    from pywayland.protocol.ext_idle_notify_v1 import (
+        ExtIdleNotifierV1, ExtIdleNotifierV1Proxy as Notifier
+    )
+except ImportError:  # pywayland < 0.4.19
+    from pywayland.protocol.wayland.wl_seat import WlSeat
+    from pywayland.protocol.ext_idle_notify_v1.ext_idle_notifier_v1 import (
+        ExtIdleNotifierV1, ExtIdleNotifierV1Proxy as Notifier
+    )
 from src.services import hyprland
 from src.services.upower import get_upower, BatteryState
 from src.services.state import is_locked, is_idle_locked
@@ -19,10 +25,17 @@ from src.services.mpris import players
 from config import Settings
 
 if t.TYPE_CHECKING:
-    from pywayland.protocol.wayland import WlRegistryProxy
-    from pywayland.protocol.ext_idle_notify_v1 import (
-        ExtIdleNotificationV1Proxy as Notification
-    )
+    try:
+        from pywayland.protocol.wayland import WlRegistryProxy
+        from pywayland.protocol.ext_idle_notify_v1 import (
+            ExtIdleNotificationV1Proxy as Notification
+        )
+    except ImportError:  # pywayland < 0.4.19
+        from pywayland.protocol.wayland.wl_registry import WlRegistryProxy
+        from pywayland.protocol.ext_idle_notify_v1\
+            .ext_idle_notification_v1 import (
+                ExtIdleNotificationV1Proxy as Notification
+            )
 
 
 WATCHER_XML_PATH = os.path.join(

--- a/hypryou/src/services/idle.py
+++ b/hypryou/src/services/idle.py
@@ -7,8 +7,8 @@ from repository import gio, glib
 from utils.logger import logger
 import typing as t
 from pywayland.client.display import Display
-from pywayland.protocol.wayland.wl_seat import WlSeat
-from pywayland.protocol.ext_idle_notify_v1.ext_idle_notifier_v1 import (
+from pywayland.protocol.wayland import WlSeat
+from pywayland.protocol.ext_idle_notify_v1 import (
     ExtIdleNotifierV1, ExtIdleNotifierV1Proxy as Notifier
 )
 from src.services import hyprland
@@ -19,8 +19,8 @@ from src.services.mpris import players
 from config import Settings
 
 if t.TYPE_CHECKING:
-    from pywayland.protocol.wayland.wl_registry import WlRegistryProxy
-    from pywayland.protocol.ext_idle_notify_v1.ext_idle_notification_v1 import (  # noqa: E501
+    from pywayland.protocol.wayland import WlRegistryProxy
+    from pywayland.protocol.ext_idle_notify_v1 import (
         ExtIdleNotificationV1Proxy as Notification
     )
 


### PR DESCRIPTION
pywayland 0.4.19 flattened the generated protocol packages into single modules: `protocol/wayland/wl_seat.py` became `protocol/wayland.py`. The nested import paths in `src/services/idle.py` no longer resolve, so HyprYou dies before the UI comes up:

File "/usr/lib/hypryou/src/services/idle.py", line 10, in <module> from pywayland.protocol.wayland.wl_seat import WlSeat
ModuleNotFoundError: No module named 'pywayland.protocol.wayland.wl_seat'; 'pywayland.protocol.wayland' is not a package

Arch's `python-pywayland` moved to 0.4.19 on 2026-08-26, so this hits anyone who updated after that.