### PR TITLE
fix: don't wipe a config file that fails to parse

### DIFF
--- a/hypryou-assets/hyprland/main.lua
+++ b/hypryou-assets/hyprland/main.lua
@@ -1,15 +1,21 @@
 ---@param path string
 local function dofileOrCreate(path)
-    local ok, err = pcall(function ()
-        dofile(path)
-    end)
-
-    if not ok then
-        local file = io.open(path, "w")
-        if file then
-            file:close()
+    local existing = io.open(path, "r")
+    if existing then
+        existing:close()
+        local ok, err = pcall(function ()
             dofile(path)
+        end)
+        if not ok then
+            print("hypryou: config error in " .. path .. ": " .. tostring(err))
         end
+        return
+    end
+
+    local file = io.open(path, "w")
+    if file then
+        file:close()
+        dofile(path)
     end
 end
 


### PR DESCRIPTION
dofileOrCreate uses pcall(dofile) as an existence check, but that fails the same way for a missing file and for one with a syntax error. Both land in the recovery branch, where io.open(path, w) truncates the file it was supposed to create. One typo in hyprland.lua is enough to lose it, and nothing is logged either way. The old main.conf did this with [ -f ] || touch, which never touched existing content.

Look the file up with io.open(path, r) and only create it when it is really missing. If it exists but does not load, print the error and leave the file alone.