### PR TITLE
fix: scrolling up on the bar doesn't switch workspaces

### DIFF
--- a/hypryou/src/modules/bar.py
+++ b/hypryou/src/modules/bar.py
@@ -163,7 +163,7 @@ class Workspaces(gtk.Box):
             action = "+1" if dy < 0 else "-1"
             asyncio.create_task(
                 hyprland.client.dispatch(
-                    f"focus({{ workspace = {action} }})"
+                    f"focus({{ workspace = \"{action}\" }})"
                 )
             )
 


### PR DESCRIPTION
focus({ workspace = +1 }) doesn't parse, Lua has no unary plus.
you surprise ? but yes 

This one working on Hyprlang, but Lua strikes again 😂 
Btw just so you know: I don't remember whether this worked infinitely or in a bounded way in Hyprland, but here it only works within the ones that  with a limit of 0-10 for me and +1 doesn't create new ones either. It just stop at treshold unless the reverse scrool takes action 